### PR TITLE
cspx-problems: runner operational improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "anyhow",
  "clap",
  "jsonschema",
+ "rayon",
  "regex",
  "serde",
  "serde_json",

--- a/crates/cspx-core/tests/refine.rs
+++ b/crates/cspx-core/tests/refine.rs
@@ -53,7 +53,7 @@ fn refinement_mismatch_fails() {
         entry: None,
     };
 
-    let checker = RefinementChecker::default();
+    let checker = RefinementChecker;
     let request = CheckRequest {
         command: CheckCommand::Refine,
         model: Some(RefinementModel::T),

--- a/crates/cspx-problems/Cargo.toml
+++ b/crates/cspx-problems/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 anyhow = { workspace = true }
 clap = { workspace = true }
 jsonschema = { workspace = true }
+rayon = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/problems/README.md
+++ b/problems/README.md
@@ -29,15 +29,15 @@ scripts/run-problems --cspx target/debug/cspx --only P000 --only P101
 ```
 
 ### 特定問題のみ実行（ディレクトリ指定）
-現状の実装は **絶対パス一致** のため、相対パス指定はマッチしない。
+相対パス・絶対パスのどちらでも指定できる。
 ```sh
-scripts/run-problems --cspx target/debug/cspx --only-dir "$(pwd)/problems/P000_hello_typecheck_pass"
+scripts/run-problems --cspx target/debug/cspx --only-dir problems/P000_hello_typecheck_pass
 ```
 
 ### 主なオプション
 - `--suite fast|bench`: suite フィルタ（デフォルト: `fast`）
 - `--cspx <path>`: `run.cmd[0] == "cspx"` の場合に `cspx` 実体を差し替える（例: `target/debug/cspx`）
-- `--jobs <n>`: 将来用（現状 `>1` は未対応で逐次実行）
+- `--jobs <n>`: 並列実行（問題単位、出力順は ID 昇順で安定化）
 
 ## CI での実行
 GitHub Actions では以下を実行する（`.github/workflows/ci.yml`）。


### PR DESCRIPTION
## 概要
Problem Suite runner（`cspx-problems`）の運用性を改善しました。

- `--only-dir` が相対パスでもマッチするように修正（`problems/P...` 形式）
- `--jobs > 1` を実装（問題単位で並列実行、出力順は ID 昇順で安定化）
- FAIL 時に `report.txt` へのパスを出力
- ドキュメント（`problems/README.md`）の記述を更新

## 動作確認
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build -p cspx && scripts/run-problems --suite fast --cspx target/debug/cspx --jobs 4`
- `scripts/run-problems --cspx target/debug/cspx --only-dir problems/P000_hello_typecheck_pass`

Refs: #62
