### PR TITLE
docs: define Frontend v0.2 subset and IR design

### DIFF
--- a/crates/cspx-core/src/ir.rs
+++ b/crates/cspx-core/src/ir.rs
@@ -1,3 +1,20 @@
+//! Core IR（v0.2 設計方針）
+//!
+//! v0.2 では Frontend（parse/typecheck）の入力として CSPM サブセットを拡張し、後続の LTS/Checker/Refinement が
+//! 追加の構文解釈に依存しないよう、IR の責務を明確化する。
+//!
+//! - AST: 字句/構文情報を保持し、Span を広く付与（実装は別モジュール）
+//! - IR: 参照解決・型（値域）整合を済ませ、探索/検査が利用しやすい形に正規化
+//!
+//! IR で扱う予定の要素（v0.2）
+//! - channel 宣言（名前、値域 `{0..N}` のみ）
+//! - process 式（STOP / prefix / choice / internal choice / interleaving / interface parallel / hiding / proc ref）
+//! - assert 宣言（deadlock/divergence/deterministic、refinement T/F/FD）
+//!
+//! エラー分類は `docs/frontend.md`（`unsupported_syntax` / `invalid_input`）に従う。
+//! Span は `SourceSpan`（1-based, inclusive）を基本とし、原因箇所（識別子/リテラル）へ最短距離で付与する。
+//! 詳細な IR 形状案は `docs/ir.md` を参照。
+
 use crate::types::SourceSpan;
 use std::fmt::Debug;
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,19 +1,91 @@
-# Frontend（M1）対応サブセット
+# Frontend 対応サブセット（v0.2）
 
 ## 目的
-M1 では `cspx typecheck` の最小実装として、CSPM の対応サブセットを限定する。
-以降の拡張は M2 以降で段階的に広げる。
+Frontend（parse/typecheck）の拡張は後続（LTS/Checker/Refinement）に波及するため、先に「CSPM サブセット v0.2」と AST/IR・エラー分類・Span 規約を固定する。
 
-## 対応構文（M1）
+## 実装状況（現行）
+現行（M1）の実装は最小サブセットのみ対応している。
 - `STOP`（トップレベル式として可）
 - 単純なプロセス定義: `NAME = STOP`
-  - `NAME` は `[A-Za-z_][A-Za-z0-9_]*`
 - 行コメント: `--` 以降は無視
 
-## 非対応（M1）
-- それ以外の CSPM 構文は `unsupported` として扱う
-- 複数のトップレベル式は `invalid_input`
+v0.2 の対応範囲は本書で定義し、実装は Phase 1（#64/#65）で段階的に追従する。
 
-## エラー分類
-- 構文的に未対応: `unsupported_syntax`（status: `unsupported`, exit code: 3）
-- 入力不正（識別子不正/重複/空ファイル等）: `invalid_input`（status: `error`, exit code: 2）
+## Problem Suite fast に出現する構文要素（棚卸し）
+v0.2 は Problem Suite（`fast`）で使用される構文を優先して定義する。
+
+- `channel` 宣言（単一/複数、値域あり）: P000, P100, P902 ほか多数
+- channel 通信（`ch!1` / `ch?x` / `fork.0`）: P100, P902, P901, P003
+- 前置（`->`）: ほぼ全問題
+- 外部選択（`[]`）: P200, P212 ほか
+- 内部選択（`|~|`）: P131, P132
+- 並行合成（interleaving `|||`）: P002
+- 並行合成（interface parallel `[|{|X|}|]`）: P100, P902 ほか
+- hiding（`\\ {|X|}`）: P121, P122, P123
+- `assert`（性質）: P100（deadlock free）, P120（divergence free）, P130（deterministic）ほか
+- `assert`（refinement）: P212（`[T=` / `[F=`）
+- 参考（意図的に未対応）: `datatype`（P004）
+
+## 対応構文（v0.2）
+### 字句
+- 識別子: `[A-Za-z_][A-Za-z0-9_]*`
+- 整数リテラル: `0|[1-9][0-9]*`
+- 行コメント: `--` 以降を無視
+
+### 宣言
+- channel 宣言
+  - `channel a`
+  - `channel ch : {0..1}`
+  - `channel send, ack, out : {0..1}`
+- プロセス定義: `NAME = <process-expr>`
+- assert 宣言
+  - 性質: `assert <proc-ref> :[deadlock free [F]]` / `:[divergence free [FD]]` / `:[deterministic [FD]]`
+  - refinement: `assert <proc-ref> [T= <proc-ref>` / `[F= ...` / `[FD= ...`
+
+### プロセス式
+- `STOP`
+- 参照: `<proc-ref>`
+- 前置: `<event> -> <process-expr>`
+- 外部選択: `<process-expr> [] <process-expr>`
+- 内部選択: `<process-expr> |~| <process-expr>`
+- interleaving: `<process-expr> ||| <process-expr>`
+- interface parallel: `<process-expr> [|{|<event-set>|}|] <process-expr>`
+- hiding: `<process-expr> \\ {|<event-set>|}`
+- 括弧: `(<process-expr>)`
+
+### event / set（v0.2）
+- event（v0.2 は「単一チャネル + 1 セグメント」までを対象とする）
+  - no-payload: `a`
+  - dot（定数）: `fork.0`
+  - output（定数/変数）: `send!0`, `out!b`
+  - input（定数/束縛）: `ack?0`, `send?b`
+- 値域（channel payload 用）: `{0..N}`（整数レンジ）
+- event-set: `{|a,b|}`（hiding / interface parallel の同期集合）
+
+### 型/名前解決（v0.2, typecheck）
+- 名前空間
+  - channel 名、process 名、変数（input による束縛）は別管理とする
+- channel 値域
+  - `channel ch : {0..N}` の場合、payload は整数かつ `[0, N]` に収まること
+  - 値域未指定（`channel a`）の channel は v0.2 では payload なし（`a`）のみを対象とする
+- 変数束縛
+  - `ch?x` の `x` は後続の process 式（`->` の右側）で参照可能とする（例: `send?b -> out!b -> ...`）
+  - `ch!x` の `x` はスコープ内で束縛済みであること（未束縛は `invalid_input`）
+  - dot 形式（`ch.0`）は v0.2 では整数リテラルのみを対象とする（`ch.A` は `unsupported_syntax`）
+
+## エラー分類（v0.2）
+CLI の status/exit code は `docs/cli.md` の規約に従う。
+
+- `unsupported_syntax`（status: `unsupported`, exit code: 3）
+  - v0.2 の字句/構文に存在しない要素（例: `datatype`、未定義の演算子、未対応のリテラル等）
+  - パーサが継続不能な構文エラー（v0.2 の字句規約に反する等）
+- `invalid_input`（status: `error`, exit code: 2）
+  - v0.2 の構文としては妥当だが、入力が不正（例: 未定義参照、重複宣言、payload が値域外、assert の target 不正等）
+
+## SourceSpan 付与規約（v0.2）
+- `start_line/start_col/end_line/end_col` は 1-based、かつ `end_*` は **終端の文字位置を含む**（inclusive）。
+- `path` は CLI から渡された入力パス文字列（相対/絶対は入力に従う）。
+- Span の優先順位（可能な限り狭く、原因箇所を指す）
+  - 未定義参照: 参照箇所（識別子）に span を付与
+  - channel payload の値域外: payload（整数）に span を付与
+  - 構文未対応: 先頭トークンから当該構文要素の終端まで（best-effort）

--- a/docs/ir.md
+++ b/docs/ir.md
@@ -1,0 +1,129 @@
+# Core IR（v0.2 設計）
+
+## 目的
+Frontend（parse/typecheck）は CSPM サブセットを読み取り、後続の LTS/Checker/Refinement が利用できる中間表現（IR）を生成する。
+v0.2 では Problem Suite（fast）で使用される構文を中心に、IR の責務と拡張方針を固定する。
+
+## 前提（v0.2）
+- CSPM サブセットは `docs/frontend.md` に従う。
+- 型（値域）は「整数レンジ `{0..N}`」のみを対象とする（`datatype` などは `unsupported_syntax`）。
+- IR は後続が扱いやすいよう **参照解決**（process/channel/変数）と **値域整合** を済ませる。
+
+## AST と IR の責務分離
+- AST
+  - 字句/構文構造を保持（エラー復元のために局所情報を保持してよい）
+  - 可能な限り全ノードに `SourceSpan` を付与
+- IR
+  - 後続処理が必要とする情報に正規化し、曖昧な構文糖を排除
+  - 名前解決・型整合を済ませ、不整合は `invalid_input` として報告
+
+## IR の基本方針（データモデル）
+`crates/cspx-core/src/ir.rs` の `Spanned<T>` を基礎とし、v0.2 では次を扱う。
+
+### 1) Channel
+- `channel a`
+- `channel ch : {0..N}`
+- `channel send, ack, out : {0..N}`
+
+IR では channel 名はユニークであること。
+値域未指定（`channel a`）は payload を持たないチャネルとして扱う。
+
+### 2) Event（channel 通信）
+v0.2 の event は「単一チャネル + 1 セグメント」まで。
+
+- no-payload: `a`
+- dot（定数）: `fork.0`
+- output（定数/変数）: `send!0`, `out!b`
+- input（定数/束縛）: `ack?0`, `send?b`
+
+IR では event を「channel + 0/1 個の通信セグメント」として表現する。
+
+### 3) Process
+process 式（v0.2）:
+- `STOP`
+- 参照
+- prefix
+- external choice（`[]`）
+- internal choice（`|~|`）
+- interleaving（`|||`）
+- interface parallel（`[|{|X|}|]`）
+- hiding（`\\ {|X|}`）
+
+IR では process 名はユニークであること。
+
+### 4) Assertion
+`assert` は後続で `check --all-assertions` を実装するために IR 上で保持する。
+
+- 性質:
+  - `deadlock free [F]`
+  - `divergence free [FD]`
+  - `deterministic [FD]`
+- refinement:
+  - `SPEC [T= IMPL`
+  - `SPEC [F= IMPL`
+  - `SPEC [FD= IMPL`
+
+## 型/名前解決（v0.2）
+### 名前空間
+channel/process/変数（input 束縛）は別管理とする。
+
+### 変数束縛
+`ch?x -> ...` の `x` は `->` の右側（継続）で参照可能とする（prefix chain を含む）。
+`ch!x` の `x` は束縛済みであること（未束縛は `invalid_input`）。
+
+### 値域
+`channel ch : {0..N}` の場合、`ch.0`/`ch!0`/`ch?0` 等の payload は整数かつ `[0, N]` に収まること。
+値域未指定の channel に payload が付く場合は `invalid_input` とする。
+
+## 提案する IR 形状（擬似コード）
+将来の実装差分が読みやすいよう、v0.2 では概ね以下の形を想定する（実装は後続 Issue）。
+
+```rust
+pub struct Module {
+  pub channels: Vec<ChannelDecl>,
+  pub processes: Vec<ProcessDecl>,
+  pub assertions: Vec<AssertionDecl>,
+  pub entry: Option<ProcessRef>,
+}
+
+pub struct ChannelDecl {
+  pub names: Vec<Spanned<Ident>>,
+  pub domain: Option<IntRange>, // None = no payload
+}
+
+pub struct IntRange { pub min: u64, pub max: u64 }
+
+pub enum EventSeg {
+  Dot(u64),
+  Out(ValueExpr),
+  In(Pattern),
+}
+
+pub enum ValueExpr { Int(u64), Var(Spanned<Ident>) }
+pub enum Pattern { Int(u64), Bind(Spanned<Ident>) }
+
+pub struct Event { pub channel: Spanned<Ident>, pub seg: Option<EventSeg> }
+
+pub enum ProcessExpr {
+  Stop,
+  Ref(Spanned<Ident>),
+  Prefix { event: Spanned<Event>, next: Box<Spanned<ProcessExpr>> },
+  Choice { kind: ChoiceKind, left: Box<Spanned<ProcessExpr>>, right: Box<Spanned<ProcessExpr>> },
+  Parallel { kind: ParallelKind, left: Box<Spanned<ProcessExpr>>, right: Box<Spanned<ProcessExpr>>, sync: EventSet },
+  Hide { inner: Box<Spanned<ProcessExpr>>, hide: EventSet },
+}
+
+pub enum ChoiceKind { External, Internal }
+pub enum ParallelKind { Interleaving, Interface }
+
+pub struct EventSet { pub channels: Vec<Spanned<Ident>> }
+
+pub enum AssertionDecl {
+  Property { target: Spanned<Ident>, kind: PropertyKind, model: PropertyModel },
+  Refinement { spec: Spanned<Ident>, model: RefinementModel, impl_: Spanned<Ident> },
+}
+```
+
+## Span（SourceSpan）規約
+Span 規約は `docs/frontend.md` に従う（1-based, inclusive）。
+IR は「原因箇所（識別子/リテラル）へ最短距離で付与」を優先する。


### PR DESCRIPTION
## 概要
CSPM サブセット v0.2（Frontend）を仕様として明文化し、AST/IR の拡張方針とエラー分類/Span 規約を整理しました。

- `docs/frontend.md`: v0.2 サブセット、fast suite 構文棚卸し、typecheck 方針、Span 規約
- `docs/ir.md`: IR 設計（責務分離、型/名前解決、擬似コード）
- `crates/cspx-core/src/ir.rs`: v0.2 方針のモジュールドキュメント追加

## 影響範囲
ドキュメントのみ（実装変更なし）。

Refs: #63
