### PR TITLE
Phase 2: LTS parallel composition (sync/interleaving)

### DIFF
--- a/crates/cspx-core/tests/lts_cspm.rs
+++ b/crates/cspx-core/tests/lts_cspm.rs
@@ -93,3 +93,85 @@ P = a -> P
     assert_eq!(stats.states, Some(1));
     assert_eq!(stats.transitions, Some(1));
 }
+
+#[test]
+fn explore_interface_parallel_sync_rendezvous_is_single_state_loop() {
+    let input = r#"channel ch : {0..1}
+Sender = ch!1 -> Sender
+Receiver = ch?x -> Receiver
+System = Sender [|{|ch|}|] Receiver
+System
+"#;
+    let frontend = SimpleFrontend;
+    let module = frontend
+        .parse_and_typecheck(input, "model.cspm")
+        .expect("parse_and_typecheck")
+        .ir;
+
+    let provider = CspmTransitionProvider::from_module(&module).expect("provider");
+    let mut store = InMemoryStateStore::new();
+    let mut queue = VecWorkQueue::new();
+    let stats = explore(&provider, &mut store, &mut queue).expect("explore");
+
+    assert_eq!(stats.states, Some(1));
+    assert_eq!(stats.transitions, Some(1));
+
+    let keyed = transitions_keyed(&provider);
+    assert_eq!(keyed.len(), 1);
+    assert_eq!(keyed[0].0, "ch.1");
+}
+
+#[test]
+fn explore_interface_parallel_deadlocks_after_one_sync() {
+    let input = r#"channel ch : {0..1}
+Sender = ch!1 -> STOP
+Receiver = ch?x -> Receiver
+System = Sender [|{|ch|}|] Receiver
+System
+"#;
+    let frontend = SimpleFrontend;
+    let module = frontend
+        .parse_and_typecheck(input, "model.cspm")
+        .expect("parse_and_typecheck")
+        .ir;
+
+    let provider = CspmTransitionProvider::from_module(&module).expect("provider");
+    let mut store = InMemoryStateStore::new();
+    let mut queue = VecWorkQueue::new();
+    let stats = explore(&provider, &mut store, &mut queue).expect("explore");
+
+    assert_eq!(stats.states, Some(2));
+    assert_eq!(stats.transitions, Some(1));
+
+    let initial = provider.initial_state();
+    let next = provider.transitions(&initial);
+    assert_eq!(next.len(), 1);
+    assert_eq!(next[0].0.label, "ch.1");
+    assert!(provider.transitions(&next[0].1).is_empty());
+}
+
+#[test]
+fn explore_interleaving_allows_independent_steps() {
+    let input = r#"channel a
+channel b
+P = a -> STOP ||| b -> STOP
+"#;
+    let frontend = SimpleFrontend;
+    let module = frontend
+        .parse_and_typecheck(input, "model.cspm")
+        .expect("parse_and_typecheck")
+        .ir;
+
+    let provider = CspmTransitionProvider::from_module(&module).expect("provider");
+    let mut store = InMemoryStateStore::new();
+    let mut queue = VecWorkQueue::new();
+    let stats = explore(&provider, &mut store, &mut queue).expect("explore");
+
+    assert_eq!(stats.states, Some(4));
+    assert_eq!(stats.transitions, Some(4));
+
+    let keyed = transitions_keyed(&provider);
+    assert_eq!(keyed.len(), 2);
+    assert_eq!(keyed[0].0, "a");
+    assert_eq!(keyed[1].0, "b");
+}


### PR DESCRIPTION
Refs: #68

## 変更内容
- `CspmTransitionProvider` で並行合成を実装
  - interface parallel: `[|{|ch|}|]`（同期集合はチャネル名で判定）
  - interleaving: `|||`（同期集合空として扱い、全てインタリーブ）
- 状態表現を `CspmState`（`Expr` / `Parallel`）へ拡張し、`CspmStateCodec` をタグ付きエンコードへ更新
- `explore()` 回帰テストを追加（P100/P101 相当 + interleaving）

## 仕様メモ
- 同期対象は `label` のチャネル部分（`ch` / `ch.<v>` の `ch`）で判定
- `tau` は同期対象外（常にインタリーブ）

## 動作確認
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build -p cspx`
- `scripts/run-problems --suite fast --cspx target/debug/cspx`

## 次
- deadlock checker への接続・problems の pass/fail 化は #70 で対応予定
