### PR TITLE
[Phase 3] Assertion: --assert 選択規約の明文化と入力検証

### DIFF
--- a/crates/cspx-core/src/assertion_select.rs
+++ b/crates/cspx-core/src/assertion_select.rs
@@ -1,0 +1,77 @@
+use crate::ir::{AssertionDecl, Module, ProcessExpr, PropertyKind, PropertyModel, Spanned};
+use std::collections::HashMap;
+
+pub(crate) fn module_for_property_check(input: &Module, kind: PropertyKind) -> Module {
+    if input.entry.is_some() || input.declarations.len() == 1 {
+        return input.clone();
+    }
+
+    let mut module = input.clone();
+    if let Some(entry) = select_last_property_assert_target_expr(input, kind) {
+        module.entry = Some(entry);
+    }
+    module
+}
+
+fn select_last_property_assert_target_expr(
+    module: &Module,
+    kind: PropertyKind,
+) -> Option<Spanned<ProcessExpr>> {
+    let mut decls = HashMap::<&str, &Spanned<ProcessExpr>>::new();
+    for decl in &module.declarations {
+        decls.insert(decl.name.value.as_str(), &decl.expr);
+    }
+
+    for assertion in module.assertions.iter().rev() {
+        let AssertionDecl::Property {
+            target,
+            kind: assert_kind,
+            ..
+        } = assertion
+        else {
+            continue;
+        };
+        if *assert_kind != kind {
+            continue;
+        }
+        if let Some(expr) = decls.get(target.value.as_str()) {
+            return Some((*expr).clone());
+        }
+    }
+    None
+}
+
+pub(crate) fn list_property_assertion_candidates(module: &Module) -> Vec<String> {
+    module
+        .assertions
+        .iter()
+        .filter_map(|assertion| match assertion {
+            AssertionDecl::Property {
+                target,
+                kind,
+                model,
+            } => Some(format!(
+                "{} :[{} [{}]]",
+                target.value,
+                property_kind_str(*kind),
+                property_model_str(*model)
+            )),
+            AssertionDecl::Refinement { .. } => None,
+        })
+        .collect()
+}
+
+pub(crate) fn property_kind_str(kind: PropertyKind) -> &'static str {
+    match kind {
+        PropertyKind::DeadlockFree => "deadlock free",
+        PropertyKind::DivergenceFree => "divergence free",
+        PropertyKind::Deterministic => "deterministic",
+    }
+}
+
+fn property_model_str(model: PropertyModel) -> &'static str {
+    match model {
+        PropertyModel::F => "F",
+        PropertyModel::FD => "FD",
+    }
+}

--- a/crates/cspx-core/src/ir.rs
+++ b/crates/cspx-core/src/ir.rs
@@ -114,14 +114,14 @@ pub struct ProcessDecl {
     pub expr: Spanned<ProcessExpr>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PropertyKind {
     DeadlockFree,
     DivergenceFree,
     Deterministic,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PropertyModel {
     F,
     FD,

--- a/crates/cspx-core/src/lib.rs
+++ b/crates/cspx-core/src/lib.rs
@@ -1,3 +1,4 @@
+mod assertion_select;
 pub mod check;
 pub mod check_deadlock;
 pub mod check_refine;

--- a/crates/cspx-core/tests/check_deadlock.rs
+++ b/crates/cspx-core/tests/check_deadlock.rs
@@ -1,0 +1,34 @@
+use cspx_core::{CheckRequest, Checker, DeadlockChecker, Frontend, SimpleFrontend, Status};
+
+#[test]
+fn deadlock_selects_last_deadlock_free_assert_target() {
+    let input = r#"-- P104: components are deadlock-free, but composition deadlocks
+channel a
+channel b
+P = a -> P
+Q = b -> Q
+System = P [|{|a,b|}|] Q
+assert P :[deadlock free [F]]
+assert Q :[deadlock free [F]]
+assert System :[deadlock free [F]]
+"#;
+
+    let frontend = SimpleFrontend;
+    let module = frontend
+        .parse_and_typecheck(input, "model.cspm")
+        .expect("parse_and_typecheck")
+        .ir;
+
+    let checker = DeadlockChecker;
+    let request = CheckRequest {
+        command: cspx_core::check::CheckCommand::Check,
+        model: None,
+        target: Some("deadlock free".to_string()),
+    };
+    let result = checker.check(&request, &module);
+    assert_eq!(result.status, Status::Fail);
+
+    let counterexample = result.counterexample.expect("counterexample");
+    assert_eq!(counterexample.source_spans.len(), 1);
+    assert_eq!(counterexample.source_spans[0].start_line, 6);
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,21 @@
 - `cspx check --all-assertions <file>`
 - `cspx refine --model T|F|FD <spec> <impl>`
 
+## `check --assert` のターゲット選択（v0.1）
+`--assert` は **性質名** を指定する（例: `"deadlock free"`）。
+
+`cspx check --assert "<ASSERT>" <file>` 実行時、検査対象（entry）は次の規約で決定する。
+
+1. `<file>` 内に `<ASSERT>` に一致する property assertion（例: `assert P :[deadlock free [F]]`）が 1 件以上ある場合、**最後に出現する assertion** の `P` を entry として採用する（last-wins）。
+2. 1) が無く、トップレベルの entry 式（宣言ではない process 式）がある場合、それを entry とする。
+3. 1) と 2) が無く、process 宣言が 1 件のみの場合、その宣言を entry とする。
+4. それ以外はエラー（entry 未指定）。
+
+`--assert` で指定できる性質名（v0.1）:
+- `"deadlock free"`
+- `"divergence free"`
+- `"deterministic"`
+
 ## 共通オプション
 - `--format json|text`（default: `json`）
 - `--output <path>`（default: stdout）


### PR DESCRIPTION
Refs #71

## 変更概要
- `docs/cli.md` に `check --assert` のターゲット選択規約（last-wins / fallback）と、受け付ける性質名を追記。
- `cspx check --assert` で未知の性質名を指定した場合は `invalid_input` とし、候補をメッセージに含める。
- deadlock 検査側は property assertion の選択処理を共通化し、entry 未指定時のエラーメッセージに候補 assertion を含める。
- 回帰テストとして「複数の `deadlock free` assertion がある場合に最後の assertion を採用する」ことを追加（P104 相当）。

## 動作確認
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `scripts/run-problems --suite fast`
