### PR TITLE
[Phase 3] CLI: --all-assertions と status/exit_code 集約

### DIFF
--- a/crates/cspx-cli/tests/golden.rs
+++ b/crates/cspx-cli/tests/golden.rs
@@ -66,6 +66,22 @@ fn golden_check_assert() {
 }
 
 #[test]
+fn golden_check_all_assertions() {
+    let actual = run_json(&[
+        "check",
+        "--all-assertions",
+        "tests/cases/all_assertions.cspm",
+        "--format",
+        "json",
+    ]);
+    let expected = load_expected("expected_check_all_assertions.json");
+    assert_eq!(
+        strip_volatile_fields(actual),
+        strip_volatile_fields(expected)
+    );
+}
+
+#[test]
 fn golden_refine() {
     let actual = run_json(&[
         "refine",

--- a/crates/cspx-cli/tests/schema_validation.rs
+++ b/crates/cspx-cli/tests/schema_validation.rs
@@ -52,6 +52,20 @@ fn schema_check_assert() {
 }
 
 #[test]
+fn schema_check_all_assertions() {
+    let schema = load_schema();
+    let actual = run_json(&[
+        "check",
+        "--all-assertions",
+        "tests/cases/all_assertions.cspm",
+        "--format",
+        "json",
+    ]);
+    let result = schema.validate(&actual);
+    assert!(result.is_ok());
+}
+
+#[test]
 fn schema_refine() {
     let schema = load_schema();
     let actual = run_json(&[

--- a/crates/cspx-core/src/ir.rs
+++ b/crates/cspx-core/src/ir.rs
@@ -127,7 +127,7 @@ pub enum PropertyModel {
     FD,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RefinementOp {
     T,
     F,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,6 +21,17 @@
 - `"divergence free"`
 - `"deterministic"`
 
+## `check --all-assertions`（v0.1）
+`cspx check --all-assertions <file>` は `<file>` 内の `assert` 宣言を **ファイル出現順** に列挙し、`checks` 配列に格納して出力する。
+
+- 未実装の assertion は `unsupported` + `reason.kind=not_implemented` とする。
+- `checks` は複数になり得る（最低 1 件）。
+
+## トップレベル status/exit_code の集約（v0.1）
+`checks` が複数ある場合、トップレベルの `status`/`exit_code` は以下の優先順位で集約する。
+
+`error` > `out_of_memory` > `timeout` > `fail` > `unsupported` > `pass`
+
 ## 共通オプション
 - `--format json|text`（default: `json`）
 - `--output <path>`（default: stdout）

--- a/problems/P212_traces_pass_but_failures_fail_demo/expect.yaml
+++ b/problems/P212_traces_pass_but_failures_fail_demo/expect.yaml
@@ -1,10 +1,27 @@
+exit_code:
+  eq: 3
 status:
-  in: ["unsupported", "error"]
+  eq: "unsupported"
 checks:
   - name:
-      in: ["check", "refine"]
+      eq: "refine"
+    model:
+      eq: "T"
+    target:
+      eq: "SPEC [T= IMPL"
     status:
-      in: ["unsupported", "error"]
+      eq: "unsupported"
     reason:
       kind:
-        in: ["unsupported_syntax", "not_implemented", "invalid_input"]
+        eq: "not_implemented"
+  - name:
+      eq: "refine"
+    model:
+      eq: "F"
+    target:
+      eq: "SPEC [F= IMPL"
+    status:
+      eq: "unsupported"
+    reason:
+      kind:
+        eq: "not_implemented"

--- a/problems/P212_traces_pass_but_failures_fail_demo/notes.md
+++ b/problems/P212_traces_pass_but_failures_fail_demo/notes.md
@@ -1,2 +1,2 @@
 T と F の差を示すデモ用途。両方の assertion を `model.cspm` に置く。
-現状は unsupported/error を期待。
+現状は refinement assertion が未実装のため、`--all-assertions` の各 check は `unsupported`（`reason.kind=not_implemented`）を期待。

--- a/tests/cases/all_assertions.cspm
+++ b/tests/cases/all_assertions.cspm
@@ -1,0 +1,5 @@
+-- all-assertions sample
+channel a
+P = a -> STOP
+assert P :[deadlock free [F]]
+assert P :[deterministic [FD]]

--- a/tests/golden/expected_check_all_assertions.json
+++ b/tests/golden/expected_check_all_assertions.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "0.1",
+  "tool": {
+    "name": "cspx",
+    "version": "0.1.0",
+    "git_sha": "UNKNOWN"
+  },
+  "invocation": {
+    "command": "check",
+    "args": [
+      "tests/cases/all_assertions.cspm"
+    ],
+    "format": "json",
+    "timeout_ms": null,
+    "memory_mb": null,
+    "seed": 0
+  },
+  "inputs": [
+    {
+      "path": "tests/cases/all_assertions.cspm",
+      "sha256": "3bf8ff56b5ffb8cc18408eb432ee0cd6dbe16b616f3b309a30b6c52d32e956b6"
+    }
+  ],
+  "status": "fail",
+  "exit_code": 1,
+  "started_at": "2026-02-06T02:59:43Z",
+  "finished_at": "2026-02-06T02:59:43Z",
+  "duration_ms": 0,
+  "checks": [
+    {
+      "name": "check",
+      "model": null,
+      "target": "P :[deadlock free [F]]",
+      "status": "fail",
+      "counterexample": {
+        "type": "trace",
+        "events": [
+          {
+            "label": "a"
+          }
+        ],
+        "is_minimized": false,
+        "tags": [
+          "deadlock"
+        ],
+        "source_spans": [
+          {
+            "path": "tests/cases/all_assertions.cspm",
+            "start_line": 3,
+            "start_col": 5,
+            "end_line": 3,
+            "end_col": 13
+          }
+        ]
+      },
+      "stats": {
+        "states": 2,
+        "transitions": 1
+      }
+    },
+    {
+      "name": "check",
+      "model": null,
+      "target": "P :[deterministic [FD]]",
+      "status": "unsupported",
+      "reason": {
+        "kind": "not_implemented",
+        "message": "assertion not implemented yet"
+      },
+      "counterexample": null,
+      "stats": {
+        "states": null,
+        "transitions": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Refs #72

## 変更概要
- `cspx check --all-assertions <file>` を実装し、model 内の `assert` を列挙して `checks` に出力する（ファイル出現順）。
- 未実装 assertion は `unsupported` + `reason.kind=not_implemented` を返す（refinement/divergence/deterministic 等）。
- トップレベル `status/exit_code` は `checks` を集約して決定する（`error` > `out_of_memory` > `timeout` > `fail` > `unsupported` > `pass`）。
- `docs/cli.md` に `--all-assertions` と集約規約を追記。
- problems/P212 の期待値を「暫定 unsupported/error」から、`--all-assertions` の未実装 refinement checks を明示する形に更新。

## テスト/回帰
- CLI の golden/schema に `--all-assertions` ケースを追加（`tests/cases/all_assertions.cspm`）。
- `scripts/run-problems --suite fast` で P212 を含む fast suite が通過することを確認。
