### PR TITLE
docs: WS1-A fast/bench運用契約をREADMEに明文化

### DIFF
--- a/problems/README.md
+++ b/problems/README.md
@@ -75,7 +75,7 @@ scripts/run-problems --suite fast --cspx target/debug/cspx
 
 ### CI 責務分離
 - `fast` のみを `ci.yml` の必須ジョブに含める
-- `bench` は別 workflow（nightly / manual。#115, #116）で運用する
+- `bench` は別 workflow（nightly / manual。#115, #116 で追加予定）で運用する
 - PR では機能回帰検知を優先し、性能回帰検知は専用導線で扱う
 
 ## 実行結果（`problems/.out`）
@@ -144,7 +144,7 @@ compare:
   - `problem.yaml`
   - `expect.yaml`
   - `notes.md`（任意）
-- 生成型の `bench` 問題は `problems/generators/` に生成手順（スクリプト/テンプレート）を置く
+- 生成型の `bench` 問題は `problems/generators/` に生成手順（スクリプト/テンプレート）を置く（`problems/generators/` は #112 で追加予定）
 
 ## `problem.yaml`
 ### 例


### PR DESCRIPTION
## 概要
Plan C / WS1-A（#111）として、Problem Suite の `fast` / `bench` 運用契約を `problems/README.md` に明文化した。

## 変更内容
- `bench` 実行手順（release build 前提）を追加
- `fast` / `bench` の責務分離と運用規約を追加
- CI責務分離（`fast` は必須、`bench` は別workflow）を明記
- 生成型 `bench` 問題の配置方針（`problems/generators/`）を追記
- Plan C 関連Issueへの参照を追加

## 検証
- `scripts/run-problems --suite fast --list`
- `scripts/run-problems --suite bench --list`

Closes #111
Refs #110
Refs #109
