### PR TITLE
[Plan C][WS6][P3] FD 並列化/POR 事前検証スパイクの文書化

### DIFF
--- a/docs/fd-optimization-backlog.md
+++ b/docs/fd-optimization-backlog.md
@@ -13,6 +13,7 @@ WS6-A（`#121`）で固定した計測導線を基準に、FD最適化の着手�
 1. P1 `#134` FD tau-closure/cycle 判定メモ化
 2. P2 `#135` FD SCC判定最適化（divergence heavy path）
 3. P3 `#136` FD 並列化/POR適用の事前検証スパイク
+   - 検証条件テンプレート: `docs/fd-parallel-por-spike.md`
 
 ## 子Issue共通ルール
 - 各Issueは、実装前に「測定対象」「成功条件」「撤退条件」を本文に明記する。

--- a/docs/fd-parallel-por-spike.md
+++ b/docs/fd-parallel-por-spike.md
@@ -1,0 +1,63 @@
+# FD 並列化/POR 事前検証スパイク（WS6-B / P3）
+
+## 目的
+- `#136` の Go/No-Go 判定に必要な検証条件を固定する。
+- FD 最適化候補（並列化 / POR）について、正当性リスクと実装コストを事前に可視化する。
+
+## 非目的
+- 本ドキュメントで本実装を確定しない。
+- 判定同値性を崩す最適化を採用しない。
+
+## 候補A: FD 探索並列化
+### 想定アプローチ
+- BFS レベル単位でノード展開を並列化し、`node_check`（divergence/refusal）を worker に分配する。
+- frontier の正規化順序を固定し、結果マージ順を deterministic に統制する。
+
+### 正当性リスク
+- 反例 trace の最短性/安定性が崩れる。
+- `fd_*` タグ（nodes/edges/pruned）の値定義が逐次実装と乖離する。
+- shared cache 導入時に更新順序依存が混入する。
+
+### 最低限の検証条件
+- 同一入力・同一 seed・同一 workers で `status` / counterexample events / tags が一致する。
+- 逐次実装との差分比較で `pass/fail` が一致する。
+- 逐次より遅い場合（中央値で +5% 以上）は不採用。
+
+## 候補B: POR（Partial Order Reduction）
+### 想定アプローチ
+- 可視イベントの独立性を満たす遷移のみ、ample set 相当の縮約を適用する。
+- τ遷移・hiding を含む節点では POR を無効化する保守的モードを初期値とする。
+
+### 正当性リスク
+- refusal 集合評価に必要な遷移を誤って削除し、偽陽性/偽陰性を招く。
+- divergence 判定の前提（τ閉包）を破壊する。
+
+### 最低限の検証条件
+- POR ON/OFF で `status`、counterexample、`fd_*` が一致すること。
+- `RefinementModel::FD` の既存テスト群（`refine` / `check_divergence`）が全通過すること。
+- 保守モード（τ/hiding検知時にPOR無効）が常に利用可能であること。
+
+## 評価テンプレート（Issue/PR 用）
+各検証Issueは以下テンプレートを埋める。
+
+- 対象: `並列化` または `POR`
+- 想定効果:
+  - 指標: `duration_ns`, `fd_divergence_checks`, `fd_impl_closure_max`
+  - 目標: `中央値 -X%`（X はPR本文で明示）
+- 正当性確認:
+  - 逐次比較コマンド:
+    - `cargo run -q -p cspx-core --example fd_divergence_bench`
+    - `scripts/run-problems --suite bench --only P905 --measure-runs 3 --warmup-runs 1`
+  - 一致判定: `status` / counterexample trace / `fd_*` tags
+- 工数見積:
+  - 実装: `S/M/L`
+  - テスト: `S/M/L`
+- 撤退条件:
+  - 判定不一致が1件でも再現した場合
+  - 速度改善が閾値未達（中央値 +5% 以上悪化含む）の場合
+
+## 依存と出口条件
+- 依存: `#134`, `#135` のマージ後を前提とする。
+- 出口条件:
+  - `#136` に Go/No-Go 判定結果を記録できること。
+  - Go の場合のみ、実装Issueを追加分割して着手すること。

--- a/docs/fd-parallel-por-spike.md
+++ b/docs/fd-parallel-por-spike.md
@@ -15,7 +15,7 @@
 
 ### 正当性リスク
 - 反例 trace の最短性/安定性が崩れる。
-- `fd_*` タグ（nodes/edges/pruned）の値定義が逐次実装と乖離する。
+- `fd_*` タグ（例: `fd_nodes` / `fd_edges` / `fd_pruned_nodes`。完全な一覧は `docs/scale.md` を参照）の値定義が逐次実装と乖離する。
 - shared cache 導入時に更新順序依存が混入する。
 
 ### 最低限の検証条件

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -252,3 +252,4 @@ deterministic mode は「スケジュールに依存しない探索順」を仕�
 - WS6-A（`#121`）の計測導線を基準に、WS6-B の優先順位付き backlog を定義した。
 - 優先順は `#134`（P1） -> `#135`（P2） -> `#136`（P3）。
 - 評価軸・検証条件・撤退条件は `docs/fd-optimization-backlog.md` を参照する。
+- `#136` の並列化/POR 事前検証テンプレートは `docs/fd-parallel-por-spike.md` を参照する。


### PR DESCRIPTION
## 概要
Issue #136 の要求（並列化/POR の事前検証条件の明文化）に対応し、Go/No-Go 判定テンプレートを文書化しました。

## 変更内容
- 追加: `docs/fd-parallel-por-spike.md`
  - 並列化候補の正当性リスク一覧
  - POR候補の適用範囲と禁止条件
  - 効果/リスク/工数の評価テンプレート
  - 撤退条件と出口条件
- 更新: `docs/fd-optimization-backlog.md`
  - P3（#136）に検証条件テンプレートへの参照を追加
- 更新: `docs/scale.md`
  - WS6-B 節に `docs/fd-parallel-por-spike.md` への導線を追加

## 意図
- 実装着手前に判定基準を固定し、正当性リスクを先に制御するため。
- 並列化/POR の検証Issueを同一フォーマットで比較可能にするため。

Refs #136
